### PR TITLE
fix: add types.d.ts to package.json `files` array

### DIFF
--- a/src/common/package.json
+++ b/src/common/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "types.d.ts",
     "src/*"
   ],
   "repository": {


### PR DESCRIPTION
This fixes missing `DecodeError` type when installed from NPM.