### PR TITLE
Minimally fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,19 +507,19 @@ $(MPG123_WASM_LIB):
 	  -I "$(MPG123_SRC)src/libmpg123" \
 	  -I "$(MPG123_SRC)src/compat" \
 	  -I "$(MPG123_DECODER_PATH)src/mpg123" \
-  	  $(MPG123_SRC)src/libmpg123/parse.c \
-  	  $(MPG123_SRC)src/libmpg123/frame.c \
-  	  $(MPG123_SRC)src/libmpg123/format.c \
-  	  $(MPG123_SRC)src/libmpg123/dct64.c \
-  	  $(MPG123_SRC)src/libmpg123/id3.c \
-  	  $(MPG123_SRC)src/libmpg123/optimize.c \
-  	  $(MPG123_SRC)src/libmpg123/readers.c \
-  	  $(MPG123_SRC)src/libmpg123/tabinit.c \
-  	  $(MPG123_SRC)src/libmpg123/libmpg123.c \
-  	  $(MPG123_SRC)src/libmpg123/layer1.c \
-  	  $(MPG123_SRC)src/libmpg123/layer2.c \
-  	  $(MPG123_SRC)src/libmpg123/layer3.c \
-  	  $(MPG123_SRC)src/libmpg123/synth_real.c 
+	  $(MPG123_SRC)src/libmpg123/parse.c \
+	  $(MPG123_SRC)src/libmpg123/frame.c \
+	  $(MPG123_SRC)src/libmpg123/format.c \
+	  $(MPG123_SRC)src/libmpg123/dct64.c \
+	  $(MPG123_SRC)src/libmpg123/id3.c \
+	  $(MPG123_SRC)src/libmpg123/optimize.c \
+	  $(MPG123_SRC)src/libmpg123/readers.c \
+	  $(MPG123_SRC)src/libmpg123/tabinit.c \
+	  $(MPG123_SRC)src/libmpg123/libmpg123.c \
+	  $(MPG123_SRC)src/libmpg123/layer1.c \
+	  $(MPG123_SRC)src/libmpg123/layer2.c \
+	  $(MPG123_SRC)src/libmpg123/layer3.c \
+	  $(MPG123_SRC)src/libmpg123/synth_real.c
 	@ echo "+-------------------------------------------------------------------------------"
 	@ echo "|"
 	@ echo "|  Successfully built: $(MPG123_WASM_LIB)"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+
 default: dist
 
-clean: dist-clean flac-wasmlib-clean opus-wasmlib-clean vorbis-wasmlib-clean mpg123-wasmlib-clean
+clean: dist-clean flac-wasmlib-clean opus-wasmlib-clean ogg-wasmlib-clean vorbis-wasmlib-clean mpg123-wasmlib-clean
 
-configure: flac-configure vorbis-configure libopus-configure mpg123-configure
+configure: flac-configure ogg-configure vorbis-configure libopus-configure mpg123-configure
 
 DEMO_PATH=demo/
 
@@ -68,7 +69,7 @@ ogg-vorbis-decoder-minify: $(OGG_VORBIS_EMSCRIPTEN_BUILD)
 
 # libvorbis
 VORBIS_WASM_LIB=$(VORBIS_SRC)lib/.libs/libvorbis.a
-vorbis-wasmlib: $(VORBIS_WASM_LIB) ogg-wasmlib
+vorbis-wasmlib: $(VORBIS_WASM_LIB)
 vorbis-wasmlib-clean: dist-clean
 	rm -rf $(VORBIS_WASM_LIB)
 	cd modules/vorbis; emmake make clean
@@ -288,7 +289,7 @@ define OGG_VORBIS_EMCC_OPTS
 $(OGG_VORBIS_DECODER_PATH)src/vorbis_decoder.c
 endef
 
-$(OGG_VORBIS_EMSCRIPTEN_BUILD): $(VORBIS_WASM_LIB)
+$(OGG_VORBIS_EMSCRIPTEN_BUILD): $(OGG_WASM_LIB) $(VORBIS_WASM_LIB)
 	@ mkdir -p $(OGG_VORBIS_DECODER_PATH)dist
 	@ echo "Building Emscripten WebAssembly module $(OGG_VORBIS_EMSCRIPTEN_BUILD)..."
 	@ emcc \
@@ -371,7 +372,7 @@ $(OPUS_DECODER_EMSCRIPTEN_BUILD): $(OPUS_WASM_LIB)
 	@ echo "|"
 	@ echo "+-------------------------------------------------------------------------------"
 
-$(OPUS_WASM_LIB): libopus-configure
+$(OPUS_WASM_LIB):
 	@ mkdir -p tmp
 	@ echo "Building Opus Emscripten Library $(OPUS_WASM_LIB)..."
 	@ emcc \

--- a/Makefile
+++ b/Makefile
@@ -71,14 +71,13 @@ ogg-vorbis-decoder-minify: $(OGG_VORBIS_EMSCRIPTEN_BUILD)
 VORBIS_WASM_LIB=$(VORBIS_SRC)lib/.libs/libvorbis.a
 vorbis-wasmlib: $(VORBIS_WASM_LIB)
 vorbis-wasmlib-clean: dist-clean
-	rm -rf $(VORBIS_WASM_LIB)
 	cd modules/vorbis; emmake make clean
 
 # libogg
 OGG_WASM_LIB=$(OGG_SRC)src/.libs/libogg.a
 ogg-wasmlib: $(OGG_WASM_LIB)
 ogg-wasmlib-clean: dist-clean
-	rm -rf $(OGG_WASM_LIB)
+	cd modules/ogg; emmake make clean
 
 # ogg-opus-decoder
 OGG_OPUS_DECODER_PATH=src/ogg-opus-decoder/

--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ ${MPG123_EMSCRIPTEN_BUILD}: $(MPG123_WASM_LIB)
 mpg123-configure:
 	cd $(MPG123_SRC); autoreconf -iv
 	cd $(MPG123_SRC); CFLAGS="-Os -flto" emconfigure ./configure \
+	  --host=wasm32-unknown-emscripten \
 	  --with-cpu=generic_dither \
 	  --with-seektable=0 \
 	  --disable-lfs-alias \

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ Decodes Ogg Vorbis data into PCM
 1. Make sure to `source` the Emscripten path in the terminal you want build in.
    * i.e. `$ source path/to/emsdk/emsdk_env.sh`
 1. Run `git submodule update --init` to clone down the git sub-modules.
+1. Run `make configure` to configure the libraries. This may appear to hang forever at 100% CPU
+   when "checking whether the C compiler works", but should eventually complete.
 1. Run `npm i` to install the build tool dependencies.
 1. Run `make clean` and `make` to build the libraries.
    * You can run `make -j8` where `8` is the number of CPU cores on your system to speed up the build.
-5. The builds will be located in each library's `dist` folder:
+1. The builds will be located in each library's `dist` folder:
    * opus-decoder: `src/opus-decoder/dist/` 
    * ogg-opus-decoder: `src/ogg-opus-decoder/dist/` 
    * mpg123-decoder: `src/mpg123-decoder/dist/` 


### PR DESCRIPTION
Hi! Thanks for your great work!  I'm writing a guide to packaging libraries using Emscripten (since no such guide seems to exist) and these are the best examples of how to do this that I've found so far.

That said, your top-level Makefile has some problems, namely:

- The ogg library is needed for the vorbis decoder, but the dependency was wrong (you need to depend on files so that Make can check if they are up to date)
- The ogg and vorbis libraries were not being cleaned correctly (you can't just remove `.libs/libogg.a`)
- There was some extra whitespace
- You need to run `make configure` (and it takes forever because of C++ insanity) in order to run `make`

Here's a PR :-)