### PR TITLE
Fix: type resolution

### DIFF
--- a/src/mpg123-decoder/package.json
+++ b/src/mpg123-decoder/package.json
@@ -4,7 +4,12 @@
   "description": "Web Assembly streaming MPEG Layer I/II/III decoder",
   "type": "module",
   "main": "./index.js",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "default": "./index.js",
+      "types":"./types.d.ts"
+    }
+  },
   "sideEffects": false,
   "types": "types.d.ts",
   "files": [


### PR DESCRIPTION
Newer typescript version require either same filenames or explicit mapping of export to type definitions